### PR TITLE
adding GetLongPath to the compressed filenames

### DIFF
--- a/SevenZip.Tests/SevenZip.Tests.csproj
+++ b/SevenZip.Tests/SevenZip.Tests.csproj
@@ -70,6 +70,9 @@
     <None Include="TestData_LongerDirectoryName\emptyfile.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+		<None Include="DirectoryWithExceptionallyLongNamedData\temp.txt">
+				<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SevenZip\SevenZip.csproj" />

--- a/SevenZip.Tests/SevenZipCompressorTests.cs
+++ b/SevenZip.Tests/SevenZipCompressorTests.cs
@@ -406,5 +406,31 @@
                 Assert.AreEqual("zip.zip", extractor.ArchiveFileNames[0]);
             }
         }
+
+        [Test]
+        public void ExceptionallyLongFileNameCompressionTest()
+        {
+            var compressor = new SevenZipCompressor
+            {
+                ArchiveFormat = OutArchiveFormat.Zip,
+                DirectoryStructure = false
+            };
+
+            FileStream fs = AlphaFS.File.Create("DirectoryWithExceptionallyLongNamedData/ThisTextDocumentHasANameThatIsExceptionallyLong123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890.txt");
+            fs.Flush();
+            fs.Dispose();
+
+            compressor.CompressDirectory("DirectoryWithExceptionallyLongNamedData", TemporaryFile);
+            Assert.IsTrue(AlphaFS.File.Exists(TemporaryFile));
+
+            using (var extractor = new SevenZipExtractor(TemporaryFile))
+            {
+                extractor.ExtractArchive(OutputDirectory);
+            }
+
+            AlphaFS.File.Delete(TemporaryFile);
+
+            Assert.AreEqual(AlphaFS.Directory.GetFiles("DirectoryWithExceptionallyLongNamedData").Select(AlphaFS.Path.GetFileName).ToArray(), AlphaFS.Directory.GetFiles(OutputDirectory).Select(AlphaFS.Path.GetFileName).ToArray());
+        }
     }
 }

--- a/SevenZip/SevenZipCompressor.cs
+++ b/SevenZip/SevenZipCompressor.cs
@@ -8,6 +8,7 @@ namespace SevenZip
 #if NET472 || NETSTANDARD2_0
     using System.Security.Permissions;
 #endif
+    
     using AlphaFS = Alphaleonis.Win32.Filesystem;
 
     using SevenZip.Sdk;
@@ -661,7 +662,7 @@ namespace SevenZip
             {
                 if (!ScanOnlyWritable)
                 {
-                    files.Add(fi.FullName);
+                    files.Add(AlphaFS.Path.GetLongPath(fi.FullName));
                 }
                 else
                 {
@@ -671,7 +672,7 @@ namespace SevenZip
                         {
                         }
 
-                        files.Add(fi.FullName);
+                        files.Add(AlphaFS.Path.GetLongPath(fi.FullName));
                     }
                     catch (IOException)
                     {
@@ -683,7 +684,7 @@ namespace SevenZip
             {
                 if (IncludeEmptyDirectories)
                 {
-                    files.Add(cdi.FullName);
+                    files.Add(AlphaFS.Path.GetLongPath(cdi.FullName));
                 }
 
                 AddFilesFromDirectory(cdi.FullName, files, searchPattern);
@@ -1314,9 +1315,9 @@ namespace SevenZip
         public void CompressDirectory(string directory, string archiveName, string password = "", string searchPattern = "*", bool recursion = true)
         {
             _compressingFilesOnDisk = true;
-            _archiveName = archiveName;
+            _archiveName = AlphaFS.Path.GetLongPath(archiveName);
 
-            using (var fs = GetArchiveFileStream(archiveName))
+            using (var fs = GetArchiveFileStream(AlphaFS.Path.GetLongPath(archiveName)))
             {
                 if (fs == null && _volumeSize == 0)
                 {
@@ -1361,7 +1362,7 @@ namespace SevenZip
             }
             else
             {
-                files.AddRange((new AlphaFS.DirectoryInfo(directory)).GetFiles(searchPattern).Select(fi => fi.FullName));
+                files.AddRange((new AlphaFS.DirectoryInfo(directory)).GetFiles(searchPattern).Select(fi => AlphaFS.Path.GetLongPath(fi.FullName)));
             }
 
             var commonRootLength = directory.Length;


### PR DESCRIPTION
adding GetLongPath to the compressed file names to hopefully resolve some DirectoryNotFoundExceptions. Also adding a test for a file name with 197 characters.